### PR TITLE
fix: move subscription card to its own full-width row

### DIFF
--- a/app/views/account/settings/show.html.erb
+++ b/app/views/account/settings/show.html.erb
@@ -44,10 +44,11 @@
       </section>
     <% end %>
 
-    <% if FastRetro.saas? && Current.user.owner? %>
-      <div class="w-full lg:w-1/2">
-        <%= render "subscription" %>
-      </div>
-    <% end %>
   </div>
+
+  <% if FastRetro.saas? && Current.user.owner? %>
+    <div class="mt-6">
+      <%= render "subscription" %>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
   1 ## Summary
   2 - Subscription card was crammed into the same flex row as Account and Team + Integrations, making text wrap badly on desktop
   3 - Move it outside the flex container so it sits below as a full-width element, matching the original intent of the `xl:col-span-2` grid behavior
   4 
   5 Follow-up to #106.
   6 
   7 ## Test plan
   8 - [x] All Rails tests pass (313 runs, 1213 assertions, 0 failures)
   9 - [ ] Visual: admin+owner SaaS view shows two cards side-by-side with subscription full-width below
  10 - [ ] Visual: non-admin member view shows single centered card, no subscription
  11 
  12 🤖 Generated with [Claude Code](https://claude.com/claude-code)