### PR TITLE
fix: prevent CSP connect-src violation on manage billing link

### DIFF
--- a/app/views/account/settings/_subscription.html.erb
+++ b/app/views/account/settings/_subscription.html.erb
@@ -56,7 +56,8 @@
         <% end %>
 
         <%= link_to t("account.settings.subscription.manage_billing"), account_billing_portal_path,
-            class: "w-full md:w-fit mx-auto flex items-center justify-center text-center bg-zinc-900 text-white hover:bg-zinc-800 px-6 py-3 text-base md:text-xl font-black tracking-wide transition-all border-[3px] border-zinc-900 shadow-[4px_4px_0px_0px_rgba(20,20,23,1)] hover:shadow-[2px_2px_0px_0px_rgba(20,20,23,1)] hover:translate-x-[2px] hover:translate-y-[2px]" %>
+            class: "w-full md:w-fit mx-auto flex items-center justify-center text-center bg-zinc-900 text-white hover:bg-zinc-800 px-6 py-3 text-base md:text-xl font-black tracking-wide transition-all border-[3px] border-zinc-900 shadow-[4px_4px_0px_0px_rgba(20,20,23,1)] hover:shadow-[2px_2px_0px_0px_rgba(20,20,23,1)] hover:translate-x-[2px] hover:translate-y-[2px]",
+            data: { turbo: false } %>
       <% end %>
     </div>
   </section>


### PR DESCRIPTION
   1 ## Summary
   2 - The "Manage Billing" link on the account settings page triggers a CSP `connect-src` violation in Sentry every time a paid user clicks it
   3 - Turbo Drive intercepts the click as a `fetch`, server redirects to Stripe's billing portal, and the redirect target violates `connect-src 'self'`
   4 - Turbo falls back to regular navigation so it still works, but generates error noise
   5 - Fix: add `data-turbo=false` to skip the fetch, matching the pattern already used on the Stripe checkout buttons in the same partial
   6 
   7 ## Test plan
   8 - [x] All Rails tests pass (313 runs, 0 failures)
   9 - [ ] Click "Manage Billing" on a paid account — should navigate to Stripe without CSP errors in console/Sentry
  10 
  11 🤖 Generated with [Claude Code](https://claude.com/claude-code)