### PR TITLE
Fix Active Storage direct uploads under account paths

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,5 +143,7 @@ Rails.application.routes.draw do
   post "stripe/webhooks", to: "stripe/webhooks#create"
 
   # Catch-all route for unmatched paths (must be last)
-  match "*unmatched", to: "errors#not_found", via: :all
+  constraints ->(request) { !request.path_info.start_with?("/rails/") } do
+    match "*unmatched", to: "errors#not_found", via: :all
+  end
 end

--- a/test/controllers/active_storage_direct_uploads_controller_test.rb
+++ b/test/controllers/active_storage_direct_uploads_controller_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+require "digest/md5"
+
+class ActiveStorageDirectUploadsControllerTest < ActionDispatch::IntegrationTest
+  test "direct uploads are handled by active storage under account paths" do
+    assert_difference -> { ActiveStorage::Blob.count } do
+      post "#{accounts(:one).slug}/rails/active_storage/direct_uploads", params: {
+        blob: {
+          filename: "avatar.png",
+          byte_size: 1,
+          checksum: Digest::MD5.base64digest("x"),
+          content_type: "image/png"
+        }
+      }, as: :json
+    end
+
+    assert_response :success
+    assert_not_nil response.parsed_body["signed_id"]
+    assert_equal "avatar.png", response.parsed_body["filename"]
+  end
+end


### PR DESCRIPTION
## Summary
- exclude `/rails/*` from the application catch-all so Rails engine routes can handle Active Storage direct uploads
- add a tenant-prefixed direct upload regression test

## Validation
- `bin/ci`

Fixes #125 