### PR TITLE
Fix auto-scroll when dragging a card during grouping

### DIFF
--- a/app/javascript/controllers/feedback_grouping_controller.js
+++ b/app/javascript/controllers/feedback_grouping_controller.js
@@ -22,6 +22,12 @@ export default class extends Controller {
     this.sortable = Sortable.create(this.listTarget, {
       // No shared group - each column is independent
       animation: 150,
+      scroll: true,
+      // Chromium doesn't auto-scroll the window during native HTML5 drags,
+      // and Sortable's AutoScroll plugin skips window scrolling unless forced
+      forceAutoScrollFallback: true,
+      scrollSensitivity: 80,
+      scrollSpeed: 15,
       ghostClass: "feedback-ghost",
       dragClass: "feedback-drag",
       chosenClass: "feedback-chosen",


### PR DESCRIPTION
Fixes #140

## Problem

With 20–30 cards in one column during the grouping phase, dragging a card from the bottom of the column to a group at the top is impossible: the page doesn't scroll while dragging (reported on Brave/macOS, applies to all Chromium browsers).

## Root cause

The retro board scrolls at the window level (the page grows with the cards; the column's inner `overflow-y-auto` is unbounded and never engages). Chromium-based browsers do not auto-scroll the window during native HTML5 drags, and SortableJS's AutoScroll plugin deliberately skips window scrolling in native-drag mode, assuming the browser handles it (`clearAutoScrolls(); return` when the nearest scrollable ancestor is the window scrolling element). Result: hovering a dragged card at the viewport edge does nothing.

## Fix

Enable SortableJS's documented escape hatch in `feedback_grouping_controller.js`:

- `forceAutoScrollFallback: true` — forces the plugin's manual scrolling path, which does scroll the window
- `scrollSensitivity: 80` — widens the edge activation zone from the 30px default so the scroll zone is comfortable to hit
- `scrollSpeed: 15`

The vendored `sortablejs` 1.15.6 already ships the AutoScroll plugin, so no dependency changes.

## Verification

Reproduced the exact scenario in a headless Chromium (grouping-phase retro, 25 cards in one column, 700px viewport, ~4400px page):

| Scenario | Window scroll while holding a dragged card at the top edge for 1.5s |
|---|---|
| Without fix (control) | 0px |
| With fix | ~960–975px |

Also verified drag-to-group still works end-to-end: dragging the bottom card onto the top card creates the group (confirmed via `feedback_group_id` in the DB), so the new options don't affect the grouping drop flow.

`bin/ci`: all tests (OSS + system + seeds), Brakeman, importmap audit, and Gitleaks pass. The two failing steps are pre-existing on `main` and untouched by this diff: rubocop `Layout/SpaceInsideArrayLiteralBrackets` offenses in the committed `db/*schema.rb` files, and bundler-audit CVEs for `concurrent-ruby` 1.3.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
