### PR TITLE
Add a premium upgrade nudge to the account menu

### DIFF
--- a/app/controllers/my/menus_controller.rb
+++ b/app/controllers/my/menus_controller.rb
@@ -3,6 +3,13 @@ class My::MenusController < ApplicationController
     @users = Current.account.users.active.alphabetically
     @accounts = Current.identity.accounts
 
-    fresh_when etag: [ @users, @accounts, Current.account ]
+    fresh_when etag: [
+      @users,
+      @accounts,
+      Current.account,
+      Current.account.subscription,
+      Current.account.billing_waiver,
+      FastRetro.saas?
+    ]
   end
 end

--- a/app/views/my/menus/_jump.html.erb
+++ b/app/views/my/menus/_jump.html.erb
@@ -20,6 +20,8 @@
 <%# === MAIN CONTENT AREA === %>
 <div class="p-5 bg-[#F8F5EC]">
 
+  <%= render "my/menus/premium_nudge" %>
+
   <%# 1. Search Field (Command Prompt Style) %>
   <div class="mb-6 group">
     <label class="block text-[0.6rem] font-bold text-zinc-500 uppercase tracking-wider mb-1"><%= t("shared.search").delete(".") %></label>

--- a/app/views/my/menus/_premium_nudge.html.erb
+++ b/app/views/my/menus/_premium_nudge.html.erb
@@ -1,0 +1,28 @@
+<% if FastRetro.saas? && Current.account.plan.free? && Current.user&.admin? %>
+  <aside id="premium-upgrade-nudge"
+         class="relative mb-6 overflow-hidden border-[2px] border-zinc-900 bg-[#6b39ff] p-4 text-white shadow-[4px_4px_0px_0px_rgba(24,24,27,1)]"
+         aria-labelledby="premium-upgrade-title">
+    <div class="absolute -right-5 -top-7 rotate-12 text-white/10" aria-hidden="true">
+      <%= icon_tag "crown", class: "text-[7rem]" %>
+    </div>
+
+    <div class="relative z-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+      <div class="max-w-[19rem]">
+        <span class="mb-2 inline-flex items-center gap-1.5 border border-zinc-900 bg-[#ffe600] px-2 py-1 text-[0.6rem] font-black uppercase tracking-widest text-zinc-900">
+          <%= icon_tag "crown", class: "text-xs" %>
+          <%= t("menus.premium_nudge.plan") %>
+        </span>
+        <h2 id="premium-upgrade-title" class="text-xl font-black uppercase leading-none tracking-tight">
+          <%= t("menus.premium_nudge.title") %>
+        </h2>
+        <p class="mt-2 text-xs font-semibold leading-snug text-white/85">
+          <%= t("menus.premium_nudge.description") %>
+        </p>
+      </div>
+
+      <%= button_to t("menus.premium_nudge.action"), account_subscription_path,
+          class: "inline-flex w-full items-center justify-center border-[2px] border-zinc-900 bg-white px-4 py-2.5 text-xs font-black uppercase tracking-widest text-zinc-900 shadow-[3px_3px_0px_0px_rgba(24,24,27,1)] transition-all duration-75 hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[1px_1px_0px_0px_rgba(24,24,27,1)] active:translate-x-[3px] active:translate-y-[3px] active:shadow-none sm:w-auto",
+          form: { class: "shrink-0", data: { turbo: false } } %>
+    </div>
+  </aside>
+<% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -456,6 +456,11 @@ de:
     open_account_menu: "Öffne dein Kontomenü"
     go_to_account_menu: "Zum Kontomenü"
     designed_by: "wurde entworfen, gebaut und betrieben von"
+    premium_nudge:
+      plan: "Kostenloser Tarif"
+      title: "Unbegrenzt Retros durchführen"
+      description: "Wechsle zu Premium und erstelle so viele Retros, wie dein Team braucht."
+      action: "Jetzt upgraden"
 
   # ── Mailers ────────────────────────────────────────────────────
   mailers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -456,6 +456,11 @@ en:
     open_account_menu: "Open your account menu"
     go_to_account_menu: "Go to account menu"
     designed_by: "is designed, built, and backed by"
+    premium_nudge:
+      plan: "Free plan"
+      title: "Unlock unlimited retros"
+      description: "Go Premium and run as many retros as your team needs."
+      action: "Go Premium"
 
   # ── Mailers ────────────────────────────────────────────────────
   mailers:

--- a/test/controllers/my/menus_controller_test.rb
+++ b/test/controllers/my/menus_controller_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class My::MenusControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @account = accounts(:one)
+    sign_in_as :one
+  end
+
+  test "shows a premium upgrade nudge to admins of free SaaS accounts" do
+    FastRetro.stubs(:saas?).returns(true)
+
+    get my_menu_path
+
+    assert_response :success
+    assert_select "#premium-upgrade-nudge" do
+      assert_select "form[action=?][method=post]", account_subscription_path
+    end
+  end
+
+  test "does not show the premium upgrade nudge outside SaaS mode" do
+    FastRetro.stubs(:saas?).returns(false)
+
+    get my_menu_path
+
+    assert_response :success
+    assert_select "#premium-upgrade-nudge", count: 0
+  end
+
+  test "does not show the premium upgrade nudge to members" do
+    logout_and_sign_in_as :two
+    FastRetro.stubs(:saas?).returns(true)
+
+    get my_menu_path
+
+    assert_response :success
+    assert_select "#premium-upgrade-nudge", count: 0
+  end
+
+  test "removes the premium upgrade nudge when the account becomes paid" do
+    FastRetro.stubs(:saas?).returns(true)
+
+    get my_menu_path
+    free_plan_etag = response.headers["ETag"]
+
+    @account.comp
+    get my_menu_path, headers: { "If-None-Match" => free_plan_etag }
+
+    assert_response :success
+    assert_select "#premium-upgrade-nudge", count: 0
+  end
+end


### PR DESCRIPTION
## Summary
- Show a premium upgrade nudge in the account menu for free-plan SaaS admins
- Expand menu cache keys so the nudge updates when subscription, billing waiver, or SaaS mode changes
- Add localized copy for English and German
- Cover the new behavior with controller integration tests

## Testing
- Added integration tests for SaaS, non-SaaS, member, and paid-account states