### PR TITLE
Add balloon pop celebration game to the complete phase

### DIFF
--- a/app/assets/stylesheets/animations.css
+++ b/app/assets/stylesheets/animations.css
@@ -94,3 +94,97 @@
 .marquee-right {
   animation: marquee-right 32s linear infinite;
 }
+
+/* Balloon popping game shown when a retro is complete */
+.balloon-arena {
+  position: relative;
+  overflow: hidden;
+  --arena-height: 20rem;
+  height: var(--arena-height);
+  touch-action: manipulation;
+  background-image: radial-gradient(#e4e4e7 1px, transparent 1px);
+  background-size: 20px 20px;
+}
+
+@keyframes balloon-float {
+  from {
+    transform: translate3d(0, 0, 0) rotate(-4deg);
+  }
+  to {
+    transform: translate3d(var(--balloon-drift), calc((var(--arena-height) + var(--balloon-height)) * -1), 0) rotate(4deg);
+  }
+}
+
+@keyframes balloon-burst {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  40% {
+    transform: scale(1.4);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0.2);
+    opacity: 0;
+  }
+}
+
+/* The game sets --balloon-left/size/drift/duration/color per balloon; these are the
+   defaults everything else in here builds on. */
+.balloon {
+  --balloon-left: 50%;
+  --balloon-size: 56px;
+  --balloon-drift: 0px;
+  --balloon-duration: 9s;
+  --balloon-color: #f43f5e;
+  --balloon-height: calc(var(--balloon-size) * 1.4);
+
+  position: absolute;
+  bottom: calc(var(--balloon-height) * -1);
+  left: var(--balloon-left);
+  width: var(--balloon-size);
+  height: var(--balloon-height);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  animation: balloon-float var(--balloon-duration) linear forwards;
+  will-change: transform;
+}
+
+.balloon__body {
+  display: block;
+  width: 100%;
+  height: calc(var(--balloon-size) * 1.15);
+  background: var(--balloon-color);
+  border: 2px solid #18181b;
+  border-radius: 50% 50% 48% 48% / 42% 42% 58% 58%;
+  box-shadow: inset -0.4rem -0.5rem 0 rgba(0, 0, 0, 0.12);
+}
+
+.balloon__string {
+  display: block;
+  width: 2px;
+  height: calc(var(--balloon-size) * 0.25);
+  margin: 0 auto;
+  background: #18181b;
+}
+
+.balloon[data-popped] {
+  pointer-events: none;
+}
+
+.balloon[data-popped] .balloon__body {
+  animation: balloon-burst 240ms ease-out forwards;
+}
+
+.balloon[data-popped] .balloon__string {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .balloon {
+    animation-duration: calc(var(--balloon-duration) * 2.5);
+  }
+}

--- a/app/components/balloon_leaderboard_component.html.erb
+++ b/app/components/balloon_leaderboard_component.html.erb
@@ -1,0 +1,23 @@
+<div id="<%= dom_id %>" class="bg-white border-[2px] border-zinc-900 shadow-[3px_3px_0px_0px_rgba(24,24,27,1)]">
+  <div class="px-4 py-3 border-b-[2px] border-zinc-900 flex items-center justify-between gap-2">
+    <h3 class="flex items-center gap-2 font-black text-sm uppercase tracking-widest text-zinc-900">
+      <%= icon_tag "leaderboard", class: "text-base" %>
+      <%= t("completes.balloon_game.leaderboard") %>
+    </h3>
+    <span class="font-mono text-xs text-zinc-500 uppercase"><%= t("completes.balloon_game.total", count: total_pops) %></span>
+  </div>
+
+  <% if any_pops? %>
+    <ol class="divide-y-[2px] divide-zinc-200">
+      <% leaders.each_with_index do |participant, index| %>
+        <li class="flex items-center gap-3 px-4 py-2.5">
+          <span class="w-7 text-center font-black text-sm text-zinc-900"><%= rank_badge(index) %></span>
+          <span class="flex-1 font-bold text-sm text-zinc-900 truncate"><%= participant.name %></span>
+          <span class="font-black text-lg text-violet-600 tabular-nums"><%= participant.balloons_popped %></span>
+        </li>
+      <% end %>
+    </ol>
+  <% else %>
+    <p class="px-4 py-8 text-center text-zinc-400 font-mono text-xs uppercase"><%= t("completes.balloon_game.no_pops") %></p>
+  <% end %>
+</div>

--- a/app/components/balloon_leaderboard_component.rb
+++ b/app/components/balloon_leaderboard_component.rb
@@ -1,0 +1,27 @@
+class BalloonLeaderboardComponent < ApplicationComponent
+  MEDALS = %w[🥇 🥈 🥉].freeze
+
+  def initialize(retro:)
+    @retro = retro
+  end
+
+  def dom_id
+    "balloon-leaderboard"
+  end
+
+  def leaders
+    @leaders ||= @retro.balloon_leaderboard.to_a
+  end
+
+  def any_pops?
+    leaders.any?
+  end
+
+  def rank_badge(index)
+    MEDALS[index] || "##{index + 1}"
+  end
+
+  def total_pops
+    leaders.sum(&:balloons_popped)
+  end
+end

--- a/app/controllers/retros/balloon_pops_controller.rb
+++ b/app/controllers/retros/balloon_pops_controller.rb
@@ -1,0 +1,39 @@
+# Records balloons popped in the celebration game of a retro's complete phase.
+#
+# The browser batches pops and posts them every second or so, which keeps the
+# request rate sane while everyone plays at the same time. Recording a batch
+# broadcasts the shared highscore to every connected client.
+class Retros::BalloonPopsController < ApplicationController
+  include RetroAuthorization
+
+  # A playing browser posts once a second, so this leaves generous headroom while
+  # still bounding a client that skips the game and posts batches in a loop. Keyed
+  # by player: a whole team behind one office IP must not share one bucket.
+  rate_limit to: 120, within: 1.minute, only: :create,
+    by: -> { Current.user&.id }, with: -> { head :too_many_requests }
+
+  before_action :set_retro
+  before_action :ensure_retro_participant
+  before_action :set_current_participant
+  before_action :ensure_complete_phase
+
+  def create
+    @current_participant.pop_balloons(params[:count])
+
+    head :created
+  end
+
+  private
+
+  def set_retro
+    @retro = Current.account.retros.find(params[:retro_id])
+  end
+
+  def set_current_participant
+    @current_participant = @retro.participants.find_by!(user: Current.user)
+  end
+
+  def ensure_complete_phase
+    head :unprocessable_entity unless @retro.complete?
+  end
+end

--- a/app/javascript/controllers/balloon_game_controller.js
+++ b/app/javascript/controllers/balloon_game_controller.js
@@ -1,0 +1,173 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Balloon popping game for the complete phase. Balloons float up through the arena,
+// clicking one pops it, and pops are batched to the server so a frantic clicker
+// doesn't fire a request per balloon. The shared highscore comes back over the
+// retro's Turbo Stream, so this controller only tracks the local score.
+const COLORS = ["#f43f5e", "#f59e0b", "#22c55e", "#38bdf8", "#a855f7", "#ec4899"]
+const SPAWN_INTERVAL = 650
+const FLUSH_INTERVAL = 1000
+const MAX_BALLOONS = 14
+const POP_ANIMATION_MS = 240
+const POP_SOUND_SECONDS = 0.12
+
+export default class extends Controller {
+  static targets = ["arena", "score"]
+
+  static values = {
+    url: String,
+    score: Number,
+    popLabel: String,
+    maxBatch: Number
+  }
+
+  connect() {
+    this.pendingPops = 0
+    this.spawnTimer = setInterval(() => this.spawn(), SPAWN_INTERVAL)
+    this.flushTimer = setInterval(() => this.flush(), FLUSH_INTERVAL)
+    this.spawn()
+  }
+
+  disconnect() {
+    clearInterval(this.spawnTimer)
+    clearInterval(this.flushTimer)
+    this.closeAudio()
+    this.flush()
+  }
+
+  pop(event) {
+    const balloon = event.target.closest(".balloon")
+    if (!balloon || balloon.hasAttribute("data-popped")) return
+
+    // Pointer and keyboard both land here (a click follows every pointerdown), so
+    // the marker above keeps a single balloon from counting twice.
+    balloon.setAttribute("data-popped", "")
+    balloon.setAttribute("aria-hidden", "true")
+    setTimeout(() => balloon.remove(), POP_ANIMATION_MS)
+
+    this.pendingPops++
+    this.scoreValue++
+    this.renderScore()
+    this.playPopSound()
+  }
+
+  renderScore() {
+    if (this.hasScoreTarget) this.scoreTarget.textContent = this.scoreValue
+  }
+
+  // The pop is synthesized instead of shipped as an audio file: a short burst of
+  // decaying noise for the bang, plus a quick downward blip for its body. Only your
+  // own clicks make a sound, so a room full of players stays bearable.
+  playPopSound() {
+    const audio = this.audioContext()
+    if (!audio) return
+
+    const startedAt = audio.currentTime
+    const volume = audio.createGain()
+    volume.gain.setValueAtTime(0.3, startedAt)
+    volume.gain.exponentialRampToValueAtTime(0.001, startedAt + POP_SOUND_SECONDS)
+    volume.connect(audio.destination)
+
+    const bang = audio.createBufferSource()
+    bang.buffer = this.noiseBuffer(audio)
+    const band = audio.createBiquadFilter()
+    band.type = "bandpass"
+    band.frequency.value = 1400
+    bang.connect(band).connect(volume)
+    bang.start(startedAt)
+
+    const blip = audio.createOscillator()
+    blip.type = "sine"
+    blip.frequency.setValueAtTime(randomBetween(700, 1000), startedAt)
+    blip.frequency.exponentialRampToValueAtTime(140, startedAt + POP_SOUND_SECONDS)
+    blip.connect(volume)
+    blip.start(startedAt)
+    blip.stop(startedAt + POP_SOUND_SECONDS)
+  }
+
+  closeAudio() {
+    this.audio?.close()
+    // Stimulus reuses the instance when the element is re-inserted, and a closed
+    // context throws on every node it is asked for - so forget it, don't reuse it.
+    this.audio = undefined
+  }
+
+  audioContext() {
+    if (this.audio === undefined) {
+      const Context = window.AudioContext || window.webkitAudioContext
+      this.audio = Context ? new Context() : null
+    }
+
+    // Browsers hand out a suspended context until a gesture arrives - and a pop is one.
+    if (this.audio?.state === "suspended") this.audio.resume()
+
+    return this.audio
+  }
+
+  noiseBuffer(audio) {
+    if (!this.noise) {
+      const samples = Math.floor(audio.sampleRate * POP_SOUND_SECONDS)
+      this.noise = audio.createBuffer(1, samples, audio.sampleRate)
+      const channel = this.noise.getChannelData(0)
+
+      for (let i = 0; i < samples; i++) {
+        channel[i] = (Math.random() * 2 - 1) * (1 - i / samples)
+      }
+    }
+
+    return this.noise
+  }
+
+  spawn() {
+    if (document.hidden || !this.hasArenaTarget) return
+    if (this.arenaTarget.childElementCount >= MAX_BALLOONS) return
+
+    this.arenaTarget.appendChild(this.buildBalloon())
+  }
+
+  buildBalloon() {
+    const balloon = document.createElement("button")
+    balloon.type = "button"
+    balloon.className = "balloon"
+    balloon.setAttribute("aria-label", this.popLabelValue)
+    balloon.style.setProperty("--balloon-left", `${randomBetween(4, 88)}%`)
+    balloon.style.setProperty("--balloon-size", `${randomBetween(40, 68)}px`)
+    balloon.style.setProperty("--balloon-drift", `${randomBetween(-40, 40)}px`)
+    balloon.style.setProperty("--balloon-duration", `${randomBetween(6, 11)}s`)
+    balloon.style.setProperty("--balloon-color", COLORS[Math.floor(Math.random() * COLORS.length)])
+    balloon.innerHTML = '<span class="balloon__body"></span><span class="balloon__string"></span>'
+    balloon.addEventListener("animationend", () => balloon.remove())
+
+    return balloon
+  }
+
+  flush() {
+    if (this.pendingPops < 1) return
+
+    // Never post more than the server accepts in one go - the rest rides along on
+    // the next flush instead of being clamped away silently.
+    const count = Math.min(this.pendingPops, this.maxBatchValue)
+    this.pendingPops -= count
+
+    fetch(this.urlValue, {
+      method: "POST",
+      keepalive: true,
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]')?.content
+      },
+      body: JSON.stringify({ count })
+    }).then(response => {
+      // A redirect means the session expired and the POST landed on the login page.
+      if (!response.ok || response.redirected) this.retry(count)
+    }).catch(() => this.retry(count))
+  }
+
+  retry(count) {
+    this.pendingPops += count
+  }
+}
+
+function randomBetween(min, max) {
+  return Math.round(min + Math.random() * (max - min))
+}

--- a/app/models/retro.rb
+++ b/app/models/retro.rb
@@ -187,6 +187,10 @@ class Retro < ApplicationRecord
     end
   end
 
+  def balloon_leaderboard
+    participants.where("balloons_popped > 0").includes(:user).order(balloons_popped: :desc, id: :asc)
+  end
+
   def owner
     participants.admin.order(:created_at).first&.user
   end

--- a/app/models/retro/participant.rb
+++ b/app/models/retro/participant.rb
@@ -1,4 +1,6 @@
 class Retro::Participant < ApplicationRecord
+  MAX_BALLOON_POPS_PER_REQUEST = 50
+
   self.table_name = "retro_participants"
 
   belongs_to :retro
@@ -27,7 +29,35 @@ class Retro::Participant < ApplicationRecord
     update!(finished: !finished)
   end
 
+  # Counts balloons popped in the celebration game of the complete phase. Pops arrive
+  # in batches from the browser, so a batch is clamped to what a human hand could
+  # manage in one flush - the controller's rate limit is what bounds a rigged client
+  # over time. Anything that isn't a number counts as no pops at all, since the
+  # count comes straight off a request.
+  #
+  # Incrementing skips callbacks, which keeps a pop from dragging the whole
+  # participant list through a broadcast - only the highscore goes out.
+  def pop_balloons(count)
+    pops = count.to_s.to_i.clamp(0, MAX_BALLOON_POPS_PER_REQUEST)
+
+    if pops.positive?
+      increment!(:balloons_popped, pops)
+      broadcast_balloon_leaderboard
+    end
+  end
+
   private
+
+  def broadcast_balloon_leaderboard
+    leaderboard = BalloonLeaderboardComponent.new(retro:)
+
+    Turbo::StreamsChannel.broadcast_replace_to(
+      retro,
+      target: leaderboard.dom_id,
+      attributes: { method: :morph },
+      html: ApplicationController.render(leaderboard, layout: false)
+    )
+  end
 
   def ensure_retro_keeps_an_admin
     if role_changed?(from: "admin", to: "participant") && retro.participants.admin.where.not(id: id).none?

--- a/app/views/retros/completes/_balloon_game.html.erb
+++ b/app/views/retros/completes/_balloon_game.html.erb
@@ -1,0 +1,34 @@
+<%# Celebration game: everyone pops balloons, the highscore updates live for all clients. %>
+<% pops = participant&.balloons_popped.to_i %>
+<div class="bg-[#F8F5EC] border-[3px] border-zinc-900 shadow-[6px_6px_0px_0px_rgba(20,20,23,0.8)]">
+  <div class="px-6 py-4 border-b-[3px] border-zinc-900 bg-white">
+    <div class="flex items-center gap-3">
+      <div class="w-3 h-3 bg-rose-500 border border-zinc-900"></div>
+      <h2 class="font-black text-xl uppercase tracking-tight text-zinc-900">"<%= t("completes.balloon_game.title") %>"</h2>
+    </div>
+    <p class="mt-1 text-xs text-zinc-500 font-mono uppercase"><%= t("completes.balloon_game.instructions") %></p>
+  </div>
+
+  <div class="p-6 grid grid-cols-1 lg:grid-cols-3 gap-6"
+       data-controller="balloon-game"
+       data-balloon-game-url-value="<%= retro_balloon_pops_path(retro) %>"
+       data-balloon-game-score-value="<%= pops %>"
+       data-balloon-game-pop-label-value="<%= t("completes.balloon_game.pop_balloon") %>"
+       data-balloon-game-max-batch-value="<%= Retro::Participant::MAX_BALLOON_POPS_PER_REQUEST %>">
+    <div class="lg:col-span-2 space-y-3">
+      <div class="flex items-center justify-between gap-3 px-4 py-2 bg-white border-[2px] border-zinc-900">
+        <span class="font-bold text-xs uppercase tracking-widest text-zinc-500"><%= t("completes.balloon_game.your_pops") %></span>
+        <span class="font-black text-2xl text-zinc-900 tabular-nums"
+              data-balloon-game-target="score"
+              aria-live="polite"><%= pops %></span>
+      </div>
+
+      <div class="balloon-arena bg-white border-[2px] border-zinc-900"
+           data-balloon-game-target="arena"
+           data-action="pointerdown->balloon-game#pop click->balloon-game#pop"
+           aria-label="<%= t("completes.balloon_game.arena_label") %>"></div>
+    </div>
+
+    <%= render BalloonLeaderboardComponent.new(retro: retro) %>
+  </div>
+</div>

--- a/app/views/retros/completes/show.html.erb
+++ b/app/views/retros/completes/show.html.erb
@@ -73,6 +73,8 @@
       </div>
     </div>
 
+    <%= render "retros/completes/balloon_game", retro: @retro, participant: @current_participant %>
+
     <%# Completion Message %>
     <div class="text-center py-8">
       <div class="inline-block bg-zinc-900 text-white px-8 py-4 border-[2px] border-zinc-900 shadow-[4px_4px_0px_0px_rgba(20,20,23,0.5)]">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -228,6 +228,15 @@ de:
     export_xlsx: "Excel exportieren (.xlsx)"
     export_csv: "CSV exportieren"
     export_jira: "Nach Jira exportieren"
+    balloon_game:
+      title: "Ballons zerplatzen"
+      instructions: "Retro geschafft - lass Ballons platzen, wer die meisten schafft, gewinnt"
+      arena_label: "Ballon-Spielfeld"
+      pop_balloon: "Ballon zerplatzen lassen"
+      your_pops: "Deine Treffer"
+      leaderboard: "Highscore"
+      total: "%{count} geplatzt"
+      no_pops: "Noch keine Ballons geplatzt"
 
   # ── Feedbacks ──────────────────────────────────────────────────
   feedbacks:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,6 +228,15 @@ en:
     export_xlsx: "Export Excel (.xlsx)"
     export_csv: "Export CSV"
     export_jira: "Export to Jira"
+    balloon_game:
+      title: "Balloon Pop"
+      instructions: "Retro's done - pop the balloons, most pops wins"
+      arena_label: "Balloon playing field"
+      pop_balloon: "Pop balloon"
+      your_pops: "Your pops"
+      leaderboard: "Highscore"
+      total: "%{count} popped"
+      no_pops: "No balloons popped yet"
 
   # ── Feedbacks ──────────────────────────────────────────────────
   feedbacks:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
         delete :remove_feedback, on: :collection
       end
       resources :votes, only: %i[create destroy]
+      resources :balloon_pops, only: :create
       resources :participants, only: [] do
         resource :role, only: :update, module: :participants
       end

--- a/db/migrate/20260815120000_add_balloons_popped_to_retro_participants.rb
+++ b/db/migrate/20260815120000_add_balloons_popped_to_retro_participants.rb
@@ -1,0 +1,5 @@
+class AddBalloonsPoppedToRetroParticipants < ActiveRecord::Migration[8.1]
+  def change
+    add_column :retro_participants, :balloons_popped, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_30_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_15_120000) do
   create_table "account_billing_waivers", force: :cascade do |t|
     t.integer "account_id", null: false
     t.datetime "created_at", null: false
@@ -181,6 +181,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_30_090000) do
   end
 
   create_table "retro_participants", force: :cascade do |t|
+    t.integer "balloons_popped", default: 0, null: false
     t.datetime "created_at", null: false
     t.boolean "finished", default: false, null: false
     t.integer "retro_id", null: false

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -8,6 +8,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       opts.add_argument("--disable-renderer-backgrounding")
       opts.add_argument("--disable-backgrounding-occluded-windows")
       opts.add_argument("--deny-permission-prompts")
+      opts.add_argument("--mute-audio")
       opts.add_argument("--enable-automation")
       opts.add_argument("--headless") if headless
     end

--- a/test/controllers/retros/balloon_pops_controller_test.rb
+++ b/test/controllers/retros/balloon_pops_controller_test.rb
@@ -1,0 +1,99 @@
+require "test_helper"
+
+class Retros::BalloonPopsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @retro = retros(:one)
+    @retro.update!(phase: :complete)
+    @participant = retro_participants(:one_admin)
+  end
+
+  test "participant records popped balloons" do
+    sign_in_as :one
+
+    post retro_balloon_pops_path(@retro), params: { count: 4 }
+
+    assert_response :created
+    assert_equal 4, @participant.reload.balloons_popped
+  end
+
+  test "pops add up across requests" do
+    sign_in_as :one
+    @participant.update!(balloons_popped: 7)
+
+    post retro_balloon_pops_path(@retro), params: { count: 3 }
+
+    assert_equal 10, @participant.reload.balloons_popped
+  end
+
+  test "pops are capped per request" do
+    sign_in_as :one
+
+    post retro_balloon_pops_path(@retro), params: { count: 10_000 }
+
+    assert_equal Retro::Participant::MAX_BALLOON_POPS_PER_REQUEST, @participant.reload.balloons_popped
+  end
+
+  test "junk counts are ignored" do
+    sign_in_as :one
+    Turbo::StreamsChannel.expects(:broadcast_replace_to).never
+
+    post retro_balloon_pops_path(@retro), params: { count: "-5" }
+
+    assert_response :created
+    assert_equal 0, @participant.reload.balloons_popped
+  end
+
+  test "a count that is not a scalar is turned away instead of blowing up" do
+    sign_in_as :one
+
+    without_action_dispatch_exception_handling do
+      post retro_balloon_pops_path(@retro), params: { count: [ "1", "2" ] }
+    end
+
+    assert_response :created
+    assert_equal 0, @participant.reload.balloons_popped
+  end
+
+  test "balloons cannot be popped before the retro is complete" do
+    sign_in_as :one
+    @retro.update!(phase: :discussion)
+
+    post retro_balloon_pops_path(@retro), params: { count: 2 }
+
+    assert_response :unprocessable_entity
+    assert_equal 0, @participant.reload.balloons_popped
+  end
+
+  test "popping broadcasts the highscore to everyone in the retro" do
+    sign_in_as :one
+    broadcast = nil
+    Turbo::StreamsChannel.stubs(:broadcast_replace_to).with do |retro, options|
+      broadcast = [ retro, options ]
+      true
+    end
+
+    post retro_balloon_pops_path(@retro), params: { count: 1 }
+
+    retro, options = broadcast
+    assert_equal @retro, retro
+    assert_equal BalloonLeaderboardComponent.new(retro: @retro).dom_id, options[:target]
+    assert_includes options[:html], users(:one).name
+    # Only the highscore travels over the wire, never a page worth of layout around it.
+    assert_not_includes options[:html], "<body"
+  end
+
+  test "retro of another account cannot be played" do
+    sign_in_as :one
+
+    post retro_balloon_pops_path(retros(:other_account_retro)), params: { count: 1 }
+
+    assert_response :not_found
+  end
+
+  test "unauthenticated user cannot pop balloons" do
+    post retro_balloon_pops_path(@retro, script_name: nil), params: { count: 1 }
+
+    assert_redirected_to session_menu_path(script_name: nil)
+    assert_equal 0, @participant.reload.balloons_popped
+  end
+end

--- a/test/controllers/retros/completes_controller_test.rb
+++ b/test/controllers/retros/completes_controller_test.rb
@@ -16,6 +16,19 @@ class Retros::CompletesControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, retro_jira_export_path(@retro)
   end
 
+  test "the balloon game and its highscore are shown to every participant" do
+    @retro.add_participant(users(:two), role: :participant)
+    retro_participants(:one_admin).update!(balloons_popped: 12)
+    sign_in_as :two
+
+    get retro_complete_path(@retro)
+
+    assert_response :success
+    assert_includes response.body, "Balloon Pop"
+    assert_includes response.body, retro_balloon_pops_path(@retro)
+    assert_includes response.body, users(:one).name
+  end
+
   test "non-admin participant does not see jira export button" do
     @retro.add_participant(users(:two), role: :participant)
     sign_in_as :two

--- a/test/javascript/balloon_game_controller.test.js
+++ b/test/javascript/balloon_game_controller.test.js
@@ -1,0 +1,261 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest"
+
+import { Application } from "@hotwired/stimulus"
+import BalloonGameController from "../../app/javascript/controllers/balloon_game_controller"
+
+describe("balloon-game controller", () => {
+  let application
+
+  function buildGame() {
+    document.body.innerHTML = `
+      <meta name="csrf-token" content="token">
+      <div id="game"
+           data-controller="balloon-game"
+           data-balloon-game-url-value="/1/retros/1/balloon_pops"
+           data-balloon-game-score-value="7"
+           data-balloon-game-pop-label-value="Pop balloon"
+           data-balloon-game-max-batch-value="50">
+        <span data-balloon-game-target="score">7</span>
+        <div data-balloon-game-target="arena"
+             data-action="pointerdown->balloon-game#pop click->balloon-game#pop"></div>
+      </div>
+    `
+  }
+
+  function arena() {
+    return document.querySelector("[data-balloon-game-target='arena']")
+  }
+
+  function score() {
+    return document.querySelector("[data-balloon-game-target='score']")
+  }
+
+  async function startedController() {
+    await Promise.resolve()
+    return application.getControllerForElementAndIdentifier(document.getElementById("game"), "balloon-game")
+  }
+
+  async function balloon() {
+    const controller = await startedController()
+    controller.spawn()
+    return arena().lastElementChild
+  }
+
+  // The fetch chain settles over several microtasks, so let them all drain.
+  async function settled() {
+    for (let i = 0; i < 3; i++) await Promise.resolve()
+  }
+
+  function popEvent(element) {
+    return new MouseEvent("pointerdown", { bubbles: true, target: element })
+  }
+
+  // Stands in for the Web Audio API, which happy-dom does not implement, and records
+  // the nodes the controller wires up for a pop.
+  function fakeAudioContext() {
+    const started = []
+    const node = () => ({ connect: vi.fn(function (target) { return target }) })
+    const context = {
+      state: "suspended",
+      currentTime: 0,
+      sampleRate: 44100,
+      resume: vi.fn(function () { context.state = "running" }),
+      close: vi.fn(),
+      destination: node(),
+      createGain: vi.fn(() => ({
+        ...node(),
+        gain: { setValueAtTime: vi.fn(), exponentialRampToValueAtTime: vi.fn() }
+      })),
+      createBiquadFilter: vi.fn(() => ({ ...node(), type: "", frequency: {} })),
+      createBuffer: vi.fn((channels, samples) => ({ getChannelData: () => new Float32Array(samples) })),
+      createBufferSource: vi.fn(() => ({ ...node(), buffer: null, start: vi.fn(() => started.push("noise")) })),
+      createOscillator: vi.fn(() => ({
+        ...node(),
+        type: "",
+        frequency: { setValueAtTime: vi.fn(), exponentialRampToValueAtTime: vi.fn() },
+        start: vi.fn(() => started.push("blip")),
+        stop: vi.fn()
+      })),
+      started
+    }
+    return context
+  }
+
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, redirected: false }))
+    buildGame()
+    application = Application.start()
+    application.register("balloon-game", BalloonGameController)
+  })
+
+  afterEach(() => {
+    application.stop()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+    document.body.innerHTML = ""
+  })
+
+  it("spawns balloons into the arena", async () => {
+    const controller = await startedController()
+    controller.spawn()
+    controller.spawn()
+
+    expect(arena().querySelectorAll(".balloon").length).toBeGreaterThanOrEqual(2)
+    expect(arena().querySelector(".balloon").getAttribute("aria-label")).toBe("Pop balloon")
+  })
+
+  it("stops spawning once the arena is full", async () => {
+    const controller = await startedController()
+
+    for (let i = 0; i < 40; i++) controller.spawn()
+
+    expect(arena().childElementCount).toBe(14)
+  })
+
+  it("counts a pop and marks the balloon as popped", async () => {
+    const controller = await startedController()
+    const target = await balloon()
+
+    target.dispatchEvent(popEvent(target))
+
+    expect(target.hasAttribute("data-popped")).toBe(true)
+    expect(controller.pendingPops).toBe(1)
+    expect(score().textContent).toBe("8")
+  })
+
+  it("counts a balloon once even though pointerdown is followed by a click", async () => {
+    const controller = await startedController()
+    const target = await balloon()
+
+    target.dispatchEvent(popEvent(target))
+    target.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+
+    expect(controller.pendingPops).toBe(1)
+    expect(score().textContent).toBe("8")
+  })
+
+  it("removes a popped balloon after the burst animation", async () => {
+    const target = await balloon()
+
+    target.dispatchEvent(popEvent(target))
+    vi.advanceTimersByTime(300)
+
+    expect(target.isConnected).toBe(false)
+  })
+
+  it("posts the pops collected since the last flush as one batch", async () => {
+    const controller = await startedController()
+    const first = await balloon()
+    const second = await balloon()
+    first.dispatchEvent(popEvent(first))
+    second.dispatchEvent(popEvent(second))
+
+    controller.flush()
+
+    expect(fetch).toHaveBeenCalledWith("/1/retros/1/balloon_pops", expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({ count: 2 })
+    }))
+    expect(controller.pendingPops).toBe(0)
+  })
+
+  it("does not post anything when no balloon was popped", async () => {
+    const controller = await startedController()
+
+    controller.flush()
+
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it("plays a pop sound on the first click and reuses the audio context after that", async () => {
+    const context = fakeAudioContext()
+    vi.stubGlobal("AudioContext", vi.fn(() => context))
+    const controller = await startedController()
+    const first = await balloon()
+    const second = await balloon()
+
+    first.dispatchEvent(popEvent(first))
+    second.dispatchEvent(popEvent(second))
+
+    expect(AudioContext).toHaveBeenCalledTimes(1)
+    expect(context.resume).toHaveBeenCalled()
+    expect(context.started).toEqual(["noise", "blip", "noise", "blip"])
+    expect(context.createBuffer).toHaveBeenCalledTimes(1)
+  })
+
+  it("pops silently when the browser has no Web Audio support", async () => {
+    vi.stubGlobal("AudioContext", undefined)
+    vi.stubGlobal("webkitAudioContext", undefined)
+    const controller = await startedController()
+    const target = await balloon()
+
+    target.dispatchEvent(popEvent(target))
+
+    expect(controller.pendingPops).toBe(1)
+  })
+
+  it("never posts a bigger batch than the server accepts and keeps the rest", async () => {
+    const controller = await startedController()
+    controller.pendingPops = 63
+
+    controller.flush()
+
+    expect(fetch).toHaveBeenCalledWith("/1/retros/1/balloon_pops", expect.objectContaining({
+      body: JSON.stringify({ count: 50 })
+    }))
+    expect(controller.pendingPops).toBe(13)
+  })
+
+  it("keeps the pops when the server rejects the batch", async () => {
+    const controller = await startedController()
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, redirected: false }))
+    const target = await balloon()
+    target.dispatchEvent(popEvent(target))
+
+    controller.flush()
+    await settled()
+
+    expect(controller.pendingPops).toBe(1)
+  })
+
+  it("keeps the pops when an expired session redirects the post to the login page", async () => {
+    const controller = await startedController()
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, redirected: true }))
+    const target = await balloon()
+    target.dispatchEvent(popEvent(target))
+
+    controller.flush()
+    await settled()
+
+    expect(controller.pendingPops).toBe(1)
+  })
+
+  it("builds a fresh audio context after a disconnect closed the old one", async () => {
+    const contexts = [ fakeAudioContext(), fakeAudioContext() ]
+    vi.stubGlobal("AudioContext", vi.fn(() => contexts.shift()))
+    const controller = await startedController()
+    const target = await balloon()
+    target.dispatchEvent(popEvent(target))
+
+    controller.disconnect()
+    controller.connect()
+    const next = await balloon()
+    next.dispatchEvent(popEvent(next))
+
+    expect(AudioContext).toHaveBeenCalledTimes(2)
+  })
+
+  it("keeps the pops for the next flush when the request fails", async () => {
+    const controller = await startedController()
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")))
+    const target = await balloon()
+    target.dispatchEvent(popEvent(target))
+
+    controller.flush()
+    await settled()
+
+    expect(controller.pendingPops).toBe(1)
+  })
+})

--- a/test/models/retro/participant_test.rb
+++ b/test/models/retro/participant_test.rb
@@ -25,6 +25,47 @@ class Retro::ParticipantTest < ActiveSupport::TestCase
     assert @admin_participant.reload.finished?
   end
 
+  test "popping balloons adds to the participant total" do
+    @admin_participant.pop_balloons(3)
+    @admin_participant.pop_balloons(2)
+
+    assert_equal 5, @admin_participant.reload.balloons_popped
+  end
+
+  test "popping balloons caps a single batch" do
+    @admin_participant.pop_balloons(Retro::Participant::MAX_BALLOON_POPS_PER_REQUEST + 100)
+
+    assert_equal Retro::Participant::MAX_BALLOON_POPS_PER_REQUEST, @admin_participant.reload.balloons_popped
+  end
+
+  test "popping balloons broadcasts the highscore without redrawing the participant list" do
+    targets = []
+    Turbo::StreamsChannel.stubs(:broadcast_replace_to).with do |_stream, options|
+      targets << options[:target]
+      true
+    end
+
+    @admin_participant.pop_balloons(2)
+
+    assert_equal [ BalloonLeaderboardComponent.new(retro: @retro).dom_id ], targets
+  end
+
+  test "popping balloons ignores counts that are not positive" do
+    @admin_participant.pop_balloons(0)
+    @admin_participant.pop_balloons(-5)
+    @admin_participant.pop_balloons("nonsense")
+
+    assert_equal 0, @admin_participant.reload.balloons_popped
+  end
+
+  test "popping balloons ignores counts that are not a scalar" do
+    @admin_participant.pop_balloons([ "1", "2" ])
+    @admin_participant.pop_balloons({ "a" => 1 })
+    @admin_participant.pop_balloons(nil)
+
+    assert_equal 0, @admin_participant.reload.balloons_popped
+  end
+
   test "role change broadcasts a page refresh to the affected user" do
     participant = @retro.participants.create!(user: users(:two), role: :participant)
 

--- a/test/models/retro_test.rb
+++ b/test/models/retro_test.rb
@@ -280,6 +280,16 @@ class RetroTest < ActiveSupport::TestCase
     end
   end
 
+  test "balloon leaderboard ranks the busiest poppers first and leaves out the idle ones" do
+    retro = retros(:one)
+    quiet = retro.participants.first
+    quiet.update!(balloons_popped: 0)
+    runner_up = retro.participants.create!(user: users(:two), balloons_popped: 4)
+    winner = retro.participants.create!(user: users(:admin), balloons_popped: 9)
+
+    assert_equal [ winner, runner_up ], retro.balloon_leaderboard.to_a
+  end
+
   private
 
   def enable_saas_mode

--- a/test/system/balloon_game_test.rb
+++ b/test/system/balloon_game_test.rb
@@ -1,0 +1,47 @@
+require "application_system_test_case"
+
+class BalloonGameTest < ApplicationSystemTestCase
+  test "popping balloons scores the participant on the highscore" do
+    retro = retros(:one)
+    retro.update!(phase: :complete)
+    sign_in_as users(:one)
+
+    visit retro_complete_path(retro)
+
+    assert_selector ".balloon-arena .balloon"
+    freeze_balloons_mid_flight
+    3.times { find(".balloon-arena .balloon:not([data-popped])", match: :first).click }
+
+    assert_selector "[data-balloon-game-target='score']", text: "3"
+    within "#balloon-leaderboard" do
+      assert_selector "li", text: users(:one).name
+      assert_selector "li", text: "3"
+    end
+    assert_equal 3, retro.participants.find_by(user: users(:one)).balloons_popped
+    # The broadcast replaces only the highscore, so the panel keeps its arena and board.
+    assert_equal 2, page.evaluate_script("document.querySelector(\"[data-controller='balloon-game']\").children.length")
+    # Stimulus swallows errors thrown inside an action into console.error, so a broken
+    # pop - Web Audio included - surfaces here rather than as a failed assertion above.
+    assert_empty browser_errors
+  end
+
+  private
+    # Balloons drift upward and remove themselves when the float ends, which makes a
+    # click race the animation. Parking them mid-flight keeps the click real without
+    # chasing a moving target.
+    def freeze_balloons_mid_flight
+      page.execute_script(<<~JS)
+        document.head.insertAdjacentHTML("beforeend",
+          "<style>.balloon { animation-delay: -3s !important; animation-play-state: paused !important; }</style>")
+      JS
+    end
+
+    def browser_errors
+      page.driver.browser.logs.get(:browser).select { |log| log.level == "SEVERE" }
+    end
+
+    def sign_in_as(user)
+      visit session_transfer_url(user.identity.transfer_id, script_name: nil)
+      assert_selector "h1", text: "YOUR RETROS"
+    end
+end


### PR DESCRIPTION
Once a retro is complete there is nothing left to do on the page but read the summary. This gives the team something to do together while the call winds down: balloons float up through an arena, anyone can pop them, and a shared highscore tracks who popped the most.

## How it works

- **`balloons_popped` counter** on `retro_participants`, incremented atomically since everyone plays at once.
- **Batched pops.** The browser collects pops and posts once a second instead of firing a request per balloon. A batch is capped at what the server accepts, and the remainder rides along on the next flush rather than being clamped away silently.
- **Live highscore.** Recording a batch broadcasts the re-rendered `BalloonLeaderboardComponent` over the retro's existing Turbo Stream, so every participant sees the board move. Incrementing deliberately skips callbacks, which keeps a pop from dragging the whole participant list through a broadcast.
- **Synthesized pop sound.** A short burst of decaying noise through a bandpass plus a falling sine blip, built with Web Audio — no audio file to ship or license, and rapid pops overlap cleanly. Only your own clicks make a sound, so a room full of players stays bearable.
- **Rate limited** per player (`by: Current.user&.id`, not by IP — a whole team behind one office NAT must not share a bucket).

## Notes for review

- Balloons are `<button>` elements, so they are keyboard-reachable, and the arena carries an `aria-label`. `prefers-reduced-motion` slows the float rather than removing it, since a game of moving targets cannot drop the motion entirely.
- Scores are not reset if a retro re-enters the complete phase; carrying them across is intentional, but say the word if you would rather they start fresh.
- `--mute-audio` was added to the system-test browser so a headed test run (`SYSTEM_TESTS_BROWSER=1`) does not blast pop sounds.

## Testing

- New: model tests (`pop_balloons` clamping, malformed input, broadcast scope), controller tests (phase gate, auth, malformed count, broadcast payload), 14 JS unit tests (spawn, pop, batching, retry, audio lifecycle), and a system test that clicks real balloons in Chrome and asserts the highscore updates.
- `bin/rails test` 434 runs · `bin/rails test test/system` 10 runs · `npm test` 22 tests · `bin/rubocop` clean.
- The system test freezes balloons mid-flight before clicking so the click does not race the float animation; ran it 5× for stability.
- Pre-existing and unrelated: `bin/ci` also flags `db/schema.rb` / cache / cable schemas under `Layout/SpaceInsideArrayLiteralBrackets` (identical on `main`), and `gitleaks` is not installed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

